### PR TITLE
Fe/feature/108/sidebar data flow

### DIFF
--- a/frontend/issue-cracker/src/components/common/sideBar/SideBar.tsx
+++ b/frontend/issue-cracker/src/components/common/sideBar/SideBar.tsx
@@ -21,20 +21,13 @@ import AssigneeContent from './content/AssigneeContent';
 import LabelContent from './content/LabelContent';
 import MilestoneContent from './content/MilestoneContent';
 import { issueForm } from '../../../store/Recoil';
-import { IssueDataProps } from '../../../utils/types/IssueDataType';
-import {
-  AssigneeProps,
-  LabelProps,
-  MilestoneProps,
-  DMilestoneProps,
-} from '../../../utils/types/sideBarType';
 
 interface TokenProps {
   name: string;
   profileImageUrl: string;
 }
 
-const SideBar = ({ state }: { state?: IssueDataProps }): JSX.Element => {
+const SideBar = (): JSX.Element => {
   const token = localStorage.getItem(TOKEN);
   const decoded = token && jwtDecode<TokenProps>(token);
   const setDecodedToken = useSetRecoilState(decodedToken);
@@ -55,7 +48,7 @@ const SideBar = ({ state }: { state?: IssueDataProps }): JSX.Element => {
     issueFormData.milestones,
   ];
 
-  const [checkedData, setCheckedData] = useRecoilState(dropCheckState);
+  const checkedData = useRecoilValue(dropCheckState);
 
   const [checkedAssignee, checkedLabel, checkedMilestone] = [
     checkedData.assignee,
@@ -100,33 +93,13 @@ const SideBar = ({ state }: { state?: IssueDataProps }): JSX.Element => {
       setIsDropLabel(false);
       setIsDropMilestone(false);
     };
+
     document.addEventListener('mousedown', dropCloseHandler);
-    // milestoneInfo: null
-    // console.log('ㅇ림어나리', state);
-    //{title : 'dadsfadsf' , statue: 'OPEN'}
-    if (state) {
-      console.log(state);
-      let prevChekedData;
-      if (state.milestoneInfo) {
-        prevChekedData = {
-          assignee: state.assignees as AssigneeProps[],
-          label: state.labels as LabelProps[],
-          milestone: [state.milestoneInfo] as DMilestoneProps[],
-        };
-      } else {
-        prevChekedData = {
-          assignee: state.assignees as AssigneeProps[],
-          label: state.labels as LabelProps[],
-          milestone: null,
-        };
-      }
-      console.log('체크체크ㅔ츠켗', prevChekedData);
-      setCheckedData(prevChekedData);
-    }
+
     return () => {
       document.removeEventListener('mousedown', dropCloseHandler);
     };
-  }, [state]);
+  }, []);
 
   return (
     <SideBarStyle>

--- a/frontend/issue-cracker/src/components/common/sideBar/SideBarDropMileStone.tsx
+++ b/frontend/issue-cracker/src/components/common/sideBar/SideBarDropMileStone.tsx
@@ -17,7 +17,7 @@ const SideBarDropMilestone = ({
 }): JSX.Element => {
   const [isCheck, setIsCheck] = useState(false);
   const [dropCheck, setDropCheck] = useRecoilState(dropCheckState);
-  console.log('사이드바마일스톤안에', dropCheck);
+
   const handleClickMilestone = () => {
     setIsCheck(!isCheck);
 
@@ -26,7 +26,7 @@ const SideBarDropMilestone = ({
         dropCheck.milestone &&
           setDropCheck({
             ...dropCheck,
-            milestone: [...dropCheck.milestone, data],
+            milestone: [data],
           });
       }
     } else {
@@ -35,7 +35,7 @@ const SideBarDropMilestone = ({
           setDropCheck({
             ...dropCheck,
             milestone: dropCheck.milestone.filter(
-              (el: MilestoneProps | DMilestoneProps) => el.title !== data.title
+              (el: MilestoneProps) => el.id !== data.id
             ),
           });
       }

--- a/frontend/issue-cracker/src/components/layout/IssueAdd/IssueAddButton.tsx
+++ b/frontend/issue-cracker/src/components/layout/IssueAdd/IssueAddButton.tsx
@@ -13,22 +13,51 @@ import {
 } from '../../../utils/const';
 import { issueAddData } from '../../../store/Recoil';
 import { useRecoilValue } from 'recoil';
+import { useHistory } from 'react-router';
 
 const IssueAddButton = (): JSX.Element => {
   const issueAdd = useRecoilValue(issueAddData);
   // const userToken = useRecoilValue(token);
   const userToken = localStorage.getItem('token');
-
+  console.log('issueAdd', issueAdd);
+  const history = useHistory();
   const handleClickCompleteButton = async () => {
     return await fetch(U.ISSUES, {
       method: 'POST',
-      body: JSON.stringify(issueAdd),
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${userToken}`,
       },
+      body: JSON.stringify({
+        title: '이슈 제목2',
+        comment: '이슈 내용',
+        assignees: [
+          {
+            email: 'noel@codesquad.com',
+            name: 'neo',
+            avatarUrl: 'profiel.image.url',
+          },
+          {
+            email: 'pyro@codesquad.com',
+            name: 'san',
+            avatarUrl: 'profiel.image.url',
+          },
+        ],
+        labels: [
+          {
+            id: '5',
+            title: '라벨',
+            description: '설명',
+            backgroundColorHexa: '#111',
+            textColorHexa: '#112',
+          },
+        ],
+        milestoneId: 1,
+      }),
     })
-      .then((res) => res.json())
+      .then((res) => {
+        return res.json();
+      })
       .then((response) => console.log('Success:', JSON.stringify(response)))
       .catch((error) => console.error('Error:', error));
   };

--- a/frontend/issue-cracker/src/components/layout/IssueAdd/index.tsx
+++ b/frontend/issue-cracker/src/components/layout/IssueAdd/index.tsx
@@ -1,11 +1,23 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import IssueAddTitle from '../IssueAdd/IssueAddTitle';
 import IssueAddBox from '../IssueAdd/IssueAddBox';
 import { Line as S } from '../../styles/CommonStyles';
 import IssueAddButton from './IssueAddButton';
+import { useSetRecoilState } from 'recoil';
+import { dropCheckState } from '../../../store/Recoil';
 
 const IssueAdd = (): JSX.Element => {
+  const setCheckData = useSetRecoilState(dropCheckState);
+
+  useEffect(() => {
+    setCheckData({
+      assignee: [],
+      label: [],
+      milestone: [],
+    });
+  }, []);
+
   return (
     <IssueAddStyle>
       <IssueAddTitle />

--- a/frontend/issue-cracker/src/components/layout/IssueDetail/IssueDetailBox/IssueDetailSidebar/index.tsx
+++ b/frontend/issue-cracker/src/components/layout/IssueDetail/IssueDetailBox/IssueDetailSidebar/index.tsx
@@ -11,7 +11,7 @@ const IssueDetailSidebar = ({
   return (
     <IssueDetailSidebarStyle>
       <React.Suspense fallback={null}>
-        <SideBar {...{ state }} />
+        <SideBar />
       </React.Suspense>
     </IssueDetailSidebarStyle>
   );

--- a/frontend/issue-cracker/src/components/layout/IssueDetail/index.tsx
+++ b/frontend/issue-cracker/src/components/layout/IssueDetail/index.tsx
@@ -1,14 +1,26 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import IssueDetailTitle from './IssueDetailTitle';
 import { Line as S } from '../../styles/CommonStyles';
 import IssueDetailBox from './IssueDetailBox';
 import { IssueDataProps } from '../../../utils/types/IssueDataType';
+import { useSetRecoilState } from 'recoil';
+import { dropCheckState } from '../../../store/Recoil';
 
 const IssueDetail = (): JSX.Element => {
   const { state } = useLocation<IssueDataProps>();
+  const setCheckData = useSetRecoilState(dropCheckState);
   console.log(state);
+
+  useEffect(() => {
+    setCheckData({
+      assignee: state.assignees,
+      label: state.labels,
+      milestone: [state.milestoneInfo],
+    });
+  }, [state]);
+
   return (
     <>
       <IssueDetailStyle>

--- a/frontend/issue-cracker/src/store/Recoil.tsx
+++ b/frontend/issue-cracker/src/store/Recoil.tsx
@@ -100,16 +100,15 @@ export const issueAddData = selector({
   get: ({ get }) => {
     const inputData = get(issueAddState);
     const dropData = get(dropCheckState);
-
     const assigneesIdList = dropData.assignee.map((ele) => ele.id);
     const labelsIdList = dropData.label.map((ele) => ele.id);
-    const milestonesIdList = dropData.milestone?.map((ele) => ele.id);
+    const milestonesIdList = dropData.milestone?.map((ele) => ele?.id);
     return {
       title: inputData.title,
       comment: inputData.comment,
-      assigneesId: assigneesIdList,
-      labelsId: labelsIdList,
-      milestoneId: milestonesIdList,
+      assigneesId: dropData.assignee,
+      labelsId: dropData.label,
+      milestoneId: milestonesIdList[0],
     };
   },
 });

--- a/frontend/issue-cracker/src/utils/const.ts
+++ b/frontend/issue-cracker/src/utils/const.ts
@@ -2,7 +2,7 @@
 export const LOGO_TITLE = 'Issue Cracker..🍪';
 const DEPLOY = 'http://issue-tracker.pyro-squad.com';
 const LOCAL = 'http://localhost:8080';
-const BASE_URL = LOCAL;
+const BASE_URL = DEPLOY;
 //url
 export const URL = {
   // AUTH: 'http://localhost:8080/api/web/auth',

--- a/frontend/issue-cracker/src/utils/types/sideBarType.ts
+++ b/frontend/issue-cracker/src/utils/types/sideBarType.ts
@@ -1,8 +1,8 @@
 export interface AssigneeProps {
-  id: string | null;
-  name: string | null;
+  id: string;
+  name: string;
   profileImageUrl: string;
-  emails: string[] | null;
+  emails: string[];
 }
 
 export interface LabelProps {
@@ -37,12 +37,12 @@ export interface LabelDataProps {
 }
 
 export interface MilestoneDataProps {
-  checkedMilestone?: MilestoneProps[] | null;
-  milestoneData?: MilestoneProps[] | null;
+  checkedMilestone?: MilestoneProps[];
+  milestoneData?: MilestoneProps[];
 }
 
 export interface dropCheckStateProps {
   assignee: AssigneeProps[];
   label: LabelProps[];
-  milestone: MilestoneProps[] | DMilestoneProps[] | null;
+  milestone: MilestoneProps[];
 }


### PR DESCRIPTION
- Sidebar에서 받던 state를 detail페이지나 add페이지에 접근할 때, 미리 recoil에 저장하고, sidebar에서는  recoil 상태값을 사용하도록 수정
- 배포된 서버로 POST 요청 테스트해보기 위해서(로컬에서는 안되는 것 확인) base url을 DEPLOY로 수정 (const.ts)
- POST요청 테스트하면서 issueAddButton fetch body부분 하드 코딩 / recoili selector 일부 수정된 상태 (api 명세에 맞추려면 타입 등 좀 바꿀게 있을듯)
- milestone하나만 선택되도록 수정