### PR TITLE
[BE] Issue 추가 시 담당자, 레이블 정보를 같이 보내도록 개선

### DIFF
--- a/backend/server/src/main/java/com/issuetracker/controller/ios/IosIssueController.java
+++ b/backend/server/src/main/java/com/issuetracker/controller/ios/IosIssueController.java
@@ -2,7 +2,7 @@ package com.issuetracker.controller.ios;
 
 import com.issuetracker.annotation.LoginRequired;
 import com.issuetracker.dto.auth.UserDto;
-import com.issuetracker.dto.request.IssueRequest;
+import com.issuetracker.dto.request.InsertIssueRequest;
 import com.issuetracker.dto.request.IssuesNumbersRequest;
 import com.issuetracker.dto.response.CommentsResponse;
 import com.issuetracker.dto.response.IssueDetailResponse;
@@ -46,10 +46,9 @@ public class IosIssueController {
 
     @PostMapping("/issues")
     @LoginRequired
-    public void createIssue(HttpServletRequest request, @RequestBody IssueRequest issue) {
-        String userId = (String) request.getAttribute("userId");
-        UserDto loginUser = authService.getUser(userId);
-        issueService.save(loginUser, issue);
+    public void createIssue(HttpServletRequest request, @RequestBody InsertIssueRequest issue) {
+        String writerId = (String) request.getAttribute("userId");
+        issueService.save(writerId, issue);
     }
 
     @GetMapping("/issues/{issueId}")

--- a/backend/server/src/main/java/com/issuetracker/controller/web/WebIssueController.java
+++ b/backend/server/src/main/java/com/issuetracker/controller/web/WebIssueController.java
@@ -43,10 +43,9 @@ public class WebIssueController {
     }
 
     @PostMapping
-//    @LoginRequired
+    @LoginRequired
     public void createIssue(HttpServletRequest request, @RequestBody InsertIssueRequest issue) {
-//        String writerId = (String) request.getAttribute("userId");
-        String writerId = "pyro";
+        String writerId = (String) request.getAttribute("userId");
         issueService.save(writerId, issue);
     }
 

--- a/backend/server/src/main/java/com/issuetracker/controller/web/WebIssueController.java
+++ b/backend/server/src/main/java/com/issuetracker/controller/web/WebIssueController.java
@@ -43,11 +43,11 @@ public class WebIssueController {
     }
 
     @PostMapping
-    @LoginRequired
-    public void createIssue(HttpServletRequest request, @RequestBody IssueRequest issue) {
-        String userId = (String) request.getAttribute("userId");
-        UserDto loginUser = authService.getUser(userId);
-        issueService.save(loginUser, issue);
+//    @LoginRequired
+    public void createIssue(HttpServletRequest request, @RequestBody InsertIssueRequest issue) {
+//        String writerId = (String) request.getAttribute("userId");
+        String writerId = "pyro";
+        issueService.save(writerId, issue);
     }
 
     @GetMapping("/{issueId}")
@@ -57,7 +57,7 @@ public class WebIssueController {
 
     @PutMapping("/{issueId}")
     @LoginRequired
-    public void updateIssue(HttpServletRequest request, @RequestBody IssueRequest issue, @PathVariable Long issueId) {
+    public void updateIssue(HttpServletRequest request, @RequestBody UpdateIssueRequest issue, @PathVariable Long issueId) {
         String loginUserId = (String) request.getAttribute("userId");
         issueService.updateIssue(loginUserId, issue, issueId);
     }

--- a/backend/server/src/main/java/com/issuetracker/domain/InsertIssue.java
+++ b/backend/server/src/main/java/com/issuetracker/domain/InsertIssue.java
@@ -1,0 +1,39 @@
+package com.issuetracker.domain;
+
+import java.util.List;
+
+public class InsertIssue {
+    private final String title;
+    private final String comment;
+    private final Long milestoneId;
+    private final List<String> assigneeIds;
+    private final List<Long> labelIds;
+
+    public InsertIssue(String title, String comment, Long milestoneId, List<String> assigneeIds, List<Long> labelIds) {
+        this.title = title;
+        this.comment = comment;
+        this.milestoneId = milestoneId;
+        this.assigneeIds = assigneeIds;
+        this.labelIds = labelIds;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public Long getMilestoneId() {
+        return milestoneId;
+    }
+
+    public List<String> getAssigneeIds() {
+        return assigneeIds;
+    }
+
+    public List<Long> getLabelIds() {
+        return labelIds;
+    }
+}

--- a/backend/server/src/main/java/com/issuetracker/domain/UpdateIssue.java
+++ b/backend/server/src/main/java/com/issuetracker/domain/UpdateIssue.java
@@ -1,11 +1,11 @@
 package com.issuetracker.domain;
 
-public class NewIssue {
+public class UpdateIssue {
     private final String title;
     private final String comment;
     private final Long milestoneId;
 
-    public NewIssue(String title, String comment, Long milestoneId) {
+    public UpdateIssue(String title, String comment, Long milestoneId) {
         this.title = title;
         this.comment = comment;
         this.milestoneId = milestoneId;
@@ -18,7 +18,7 @@ public class NewIssue {
     public String getComment() {
         return comment;
     }
-    
+
     public Long getMilestoneId() {
         return milestoneId;
     }

--- a/backend/server/src/main/java/com/issuetracker/dto/request/InsertIssueRequest.java
+++ b/backend/server/src/main/java/com/issuetracker/dto/request/InsertIssueRequest.java
@@ -1,0 +1,45 @@
+package com.issuetracker.dto.request;
+
+import com.issuetracker.domain.InsertIssue;
+
+import java.util.List;
+
+public class InsertIssueRequest {
+    private final String title;
+    private final String comment;
+    private final Long milestoneId;
+    private final List<String> assigneeIds;
+    private final List<Long> labelIds;
+
+    public InsertIssueRequest(String title, String comment, Long milestoneId, List<String> assigneeIds, List<Long> labelIds) {
+        this.title = title;
+        this.comment = comment;
+        this.milestoneId = milestoneId;
+        this.assigneeIds = assigneeIds;
+        this.labelIds = labelIds;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public Long getMilestoneId() {
+        return milestoneId;
+    }
+
+    public List<String> getAssigneeIds() {
+        return assigneeIds;
+    }
+
+    public List<Long> getLabelIds() {
+        return labelIds;
+    }
+
+    public InsertIssue toInsertIssue() {
+        return new InsertIssue(title, comment, milestoneId, assigneeIds, labelIds);
+    }
+}

--- a/backend/server/src/main/java/com/issuetracker/dto/request/UpdateIssueRequest.java
+++ b/backend/server/src/main/java/com/issuetracker/dto/request/UpdateIssueRequest.java
@@ -1,13 +1,13 @@
 package com.issuetracker.dto.request;
 
-import com.issuetracker.domain.NewIssue;
+import com.issuetracker.domain.UpdateIssue;
 
-public class IssueRequest {
+public class UpdateIssueRequest {
     private final String title;
     private final String comment;
     private final Long milestoneId;
 
-    public IssueRequest(String title, String comment, Long milestoneId) {
+    public UpdateIssueRequest(String title, String comment, Long milestoneId) {
         this.title = title;
         this.comment = comment;
         this.milestoneId = milestoneId;
@@ -20,12 +20,12 @@ public class IssueRequest {
     public String getComment() {
         return comment;
     }
-    
+
     public Long getMilestoneId() {
         return milestoneId;
     }
 
-    public NewIssue toNewIssue() {
-        return new NewIssue(title, comment, milestoneId);
+    public UpdateIssue toUpdateIssue() {
+        return new UpdateIssue(title, comment, milestoneId);
     }
 }

--- a/backend/server/src/main/java/com/issuetracker/service/IssueService.java
+++ b/backend/server/src/main/java/com/issuetracker/service/IssueService.java
@@ -37,8 +37,8 @@ public class IssueService {
         return IssueOptionResponse.from(issueRepository.findIssueOption());
     }
 
-    public void save(UserDto userDto, IssueRequest issueDto) {
-        issueRepository.save(userDto.toUser(), issueDto.toNewIssue());
+    public void save(String writerId, InsertIssueRequest issueDto) {
+        issueRepository.save(writerId, issueDto.toInsertIssue());
     }
 
     public IssueDetailResponse findDetailedIssueId(Long issueId) {
@@ -66,14 +66,14 @@ public class IssueService {
         }
     }
 
-    public void updateIssue(String loginUserId, IssueRequest updateIssue, Long issueId) {
+    public void updateIssue(String loginUserId, UpdateIssueRequest updateIssue, Long issueId) {
         Issue findIssue = issueRepository.findIssueById(issueId);
 
         if (!findIssue.getWriter().getId().equals(loginUserId)) {
             throw new AuthenticationException("인증되지 않은 유저입니다.");
         }
 
-        issueRepository.updateIssue(updateIssue.toNewIssue(), issueId);
+        issueRepository.updateIssue(updateIssue.toUpdateIssue(), issueId);
 
     }
 
@@ -82,13 +82,7 @@ public class IssueService {
         if (!findIssue.getWriter().getId().equals(writerId)) {
             throw new AuthenticationException("인증되지 않은 유저입니다.");
         }
-        issueRepository.deleteAssignees(issueId);
-
-
-        for (String assignee : assigneeRequest.getAssigneeIds()) {
-            issueRepository.addAssignees(issueId, assignee);
-        }
-
+        issueRepository.updateAssigneesOfIssue(issueId, assigneeRequest.getAssigneeIds());
     }
 
     public void addLabels(LabelNumbersRequest labels, String writerId, Long issueId) {
@@ -96,11 +90,6 @@ public class IssueService {
         if (!findIssue.getWriter().getId().equals(writerId)) {
             throw new AuthenticationException("인증되지 않은 유저입니다.");
         }
-        issueRepository.deleteLabelsOfIssue(issueId);
-
-        for (Long labelId : labels.getLabelIds()) {
-            issueRepository.addLabelOfIssue(issueId, labelId);
-        }
-
+        issueRepository.updateLabelsOfIssue(issueId, labels.getLabelIds());
     }
 }


### PR DESCRIPTION
귀찮아서 트랜잭션처리 생략하고 마구잡이로 구현했습니다.
트랜잭션 처리는 JPA 도입한 이후에 하려고 합니다.
지금 공들여봐야, 어차피 다 지우고 JPA 로 바꾸어야 하니까요.