### PR TITLE
feat: 이슈 생성시 생성된 이슈 아이디를 리턴

### DIFF
--- a/backend/server/src/main/java/com/issuetracker/controller/web/WebIssueController.java
+++ b/backend/server/src/main/java/com/issuetracker/controller/web/WebIssueController.java
@@ -44,9 +44,9 @@ public class WebIssueController {
 
     @PostMapping
     @LoginRequired
-    public void createIssue(HttpServletRequest request, @RequestBody InsertIssueRequest issue) {
+    public long createIssue(HttpServletRequest request, @RequestBody InsertIssueRequest issue) {
         String writerId = (String) request.getAttribute("userId");
-        issueService.save(writerId, issue);
+        return issueService.save(writerId, issue);
     }
 
     @GetMapping("/{issueId}")

--- a/backend/server/src/main/java/com/issuetracker/service/IssueService.java
+++ b/backend/server/src/main/java/com/issuetracker/service/IssueService.java
@@ -44,8 +44,8 @@ public class IssueService {
         return IssueOptionResponse.from(issueRepository.findIssueOption());
     }
 
-    public void save(String writerId, InsertIssueRequest issueDto) {
-        issueRepository.save(writerId, issueDto.toInsertIssue());
+    public long save(String writerId, InsertIssueRequest issueDto) {
+        return issueRepository.save(writerId, issueDto.toInsertIssue());
     }
 
     public IssueDetailResponse findDetailedIssueId(Long issueId) {


### PR DESCRIPTION
https://www.baeldung.com/spring-jdbc-autogenerated-keys 을 보고

`SELECT LAST_INSERT_ID` 대신
스프링 프레임워크의 jdbc에서 제공하는 KeyHolder 를 통해 INSERT 한 개체의 ID를 가져올 수 있음을 알게 돼, 
적용을 해보았는데 혹시 마음에 안 드시면 원래대로 돌려놓겠습니다! 