### PR TITLE
[FE] 마일스톤 편집 및 삭제 기능

### DIFF
--- a/frontend/issue-cracker/src/components/common/group/TabGroup.tsx
+++ b/frontend/issue-cracker/src/components/common/group/TabGroup.tsx
@@ -30,7 +30,13 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 );
 
-const TabGroup = (): JSX.Element => {
+const TabGroup = ({
+  labelCount,
+  milestoneCount,
+}: {
+  labelCount?: number;
+  milestoneCount?: number;
+}): JSX.Element => {
   const classes = useStyles();
 
   return (
@@ -47,7 +53,7 @@ const TabGroup = (): JSX.Element => {
           to={P.ISSUE_LABELLIST}
         >
           <TextGroup type={T.SMALL} content={TT.LABEL} color="#6E7191" />
-          <CountGroup count={0} color="#6E7191" />
+          <CountGroup count={!labelCount ? 0 : labelCount} color="#6E7191" />
         </Button>
 
         <Button
@@ -57,7 +63,10 @@ const TabGroup = (): JSX.Element => {
           to={P.ISSUE_MILESTONE}
         >
           <TextGroup type={T.SMALL} content={TT.MILESTONE} color="#6E7191" />
-          <CountGroup count={1} color="#6E7191" />
+          <CountGroup
+            count={!milestoneCount ? 0 : milestoneCount}
+            color="#6E7191"
+          />
         </Button>
       </CustomTabGroup>
     </div>

--- a/frontend/issue-cracker/src/components/layout/LabelList/LabelAdd/index.tsx
+++ b/frontend/issue-cracker/src/components/layout/LabelList/LabelAdd/index.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../../../utils/const';
 import { Issue as S } from '../../../styles/CommonStyles';
 import { getPost } from '../../../../utils/restAPI';
+
 const LabelAdd = (): JSX.Element => {
   const setLabelAddState = useSetRecoilState(labelAddState);
   const userToken = localStorage.getItem('token');

--- a/frontend/issue-cracker/src/components/layout/LabelList/LabelTable/index.tsx
+++ b/frontend/issue-cracker/src/components/layout/LabelList/LabelTable/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styled from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { labelAddState } from '../../../../store/Recoil';

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneAdd/MilestoneAddCompleteButton.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneAdd/MilestoneAddCompleteButton.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from 'styled-components';
+import ButtonGroup from '../../../common/group/ButtonGroup';
+import { getPost } from '../../../../utils/restAPI';
+import {
+  BUTTON_SIZE as BS,
+  BUTTON_NAME as BN,
+  URL as U,
+} from '../../../../utils/const';
+import AddIcon from '@material-ui/icons/Add';
+import { useSetRecoilState, useRecoilValue } from 'recoil';
+import {
+  milestoneAddInputState,
+  milestoneAddState,
+} from '../../../../store/Recoil';
+
+const MilestoneAddCompleteButton = (): JSX.Element => {
+  const setMilestoneAdd = useSetRecoilState(milestoneAddState);
+  const milestoneAddInput = useRecoilValue(milestoneAddInputState);
+  const userToken = localStorage.getItem('token');
+
+  const handleClickButton = () => {
+    getPost(U.MILESTONE, userToken, milestoneAddInput);
+    setMilestoneAdd((prev) => !prev);
+  };
+
+  return (
+    <ButtonBox onClick={handleClickButton}>
+      <ButtonGroup
+        type={BS.SMALL_FILL}
+        name={BN.COMPLETE}
+        icon={<AddIcon style={{ fontSize: 16 }} />}
+      />
+    </ButtonBox>
+  );
+};
+
+export default MilestoneAddCompleteButton;
+
+const ButtonBox = styled.div`
+  display: flex;
+`;

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneAdd/MilestoneAddDescription.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneAdd/MilestoneAddDescription.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
+import { TYPE as T, MILESTONE as M } from '../../../../utils/const';
+import { milestoneAddInputState } from '../../../../store/Recoil';
+import InputGroup from '../../../common/group/InputGroup';
+
+const MilestoneAddDescription = (): JSX.Element => {
+  const [milestoneAddInput, setMilestoneAddInput] = useRecoilState(
+    milestoneAddInputState
+  );
+
+  const handleChangeInputDescription = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ): void =>
+    setMilestoneAddInput({
+      ...milestoneAddInput,
+      description: e.target.value,
+    });
+
+  return (
+    <InputBox>
+      <InputGroup
+        variant="outlined"
+        name={M.DESC}
+        type={T.LARGE}
+        onChange={handleChangeInputDescription}
+      />
+    </InputBox>
+  );
+};
+
+export default MilestoneAddDescription;
+
+const InputBox = styled.div`
+  padding: 10px 20px;
+  width: 100%;
+
+  div {
+    width: 100%;
+  }
+
+  input {
+    background: #eff0f6;
+    border-radius: 16px;
+  }
+
+  fieldset {
+    border-radius: 16px;
+  }
+`;

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneAdd/MilestoneAddDueDate.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneAdd/MilestoneAddDueDate.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import styled from 'styled-components';
+import { TYPE as T, MILESTONE as M } from '../../../../utils/const';
+import InputGroup from '../../../common/group/InputGroup';
+
+const MilestoneAddDueDate = (): JSX.Element => {
+  return (
+    <InputBox>
+      <InputGroup variant="outlined" name={M.DUE} type={T.LARGE} />
+    </InputBox>
+  );
+};
+
+export default MilestoneAddDueDate;
+
+const InputBox = styled.div`
+  padding: 10px 20px;
+  width: 100%;
+
+  div {
+    width: 100%;
+  }
+
+  input {
+    background: #eff0f6;
+    border-radius: 16px;
+  }
+
+  fieldset {
+    border-radius: 16px;
+  }
+`;

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneAdd/MilestoneAddHeader.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneAdd/MilestoneAddHeader.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import styled from 'styled-components';
+import TextGroup from '../../../common/group/TextGroup';
+import { TYPE as T, MILESTONE as M } from '../../../../utils/const';
+import { Issue as S } from '../../../styles/CommonStyles';
+
+const MilestoneAddHeader = (): JSX.Element => {
+  return (
+    <MilestoneAddHeaderStyle>
+      <TextBox>
+        <TextGroup type={T.LARGE} content={M.ADD} color="#14142B" />
+      </TextBox>
+    </MilestoneAddHeaderStyle>
+  );
+};
+
+export default MilestoneAddHeader;
+
+const MilestoneAddHeaderStyle = styled(S.IssueTableHeader)`
+  background: #fff;
+  border-bottom: none;
+  padding-bottom: 30px;
+  height: fit-content;
+`;
+
+const TextBox = styled.div`
+  margin-left: 20px;
+  margin-top: 20px;
+`;

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneAdd/MilestoneAddName.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneAdd/MilestoneAddName.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
+import { TYPE as T, MILESTONE as M } from '../../../../utils/const';
+import { milestoneAddInputState } from '../../../../store/Recoil';
+import InputGroup from '../../../common/group/InputGroup';
+
+const MilestoneAddName = (): JSX.Element => {
+  const [milestoneAddInput, setMilestoneAddInput] = useRecoilState(
+    milestoneAddInputState
+  );
+
+  const handleChangeInputTitle = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ): void =>
+    setMilestoneAddInput({
+      ...milestoneAddInput,
+      title: e.target.value,
+    });
+
+  return (
+    <InputBox>
+      <InputGroup
+        variant="outlined"
+        name={M.NAME}
+        type={T.LARGE}
+        onChange={handleChangeInputTitle}
+      />
+    </InputBox>
+  );
+};
+
+export default MilestoneAddName;
+
+const InputBox = styled.div`
+  padding: 10px 20px;
+  width: 100%;
+
+  div {
+    width: 100%;
+  }
+
+  input {
+    background: #eff0f6;
+    border-radius: 16px;
+  }
+
+  fieldset {
+    border-radius: 16px;
+  }
+`;

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneAdd/index.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneAdd/index.tsx
@@ -1,94 +1,29 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Issue as S } from '../../../styles/CommonStyles';
-import TextGroup from '../../../common/group/TextGroup';
-import InputGroup from '../../../common/group/InputGroup';
-import ButtonGroup from '../../../common/group/ButtonGroup';
-import { getPost } from '../../../../utils/restAPI';
-import {
-  TYPE as T,
-  MILESTONE as M,
-  BUTTON_SIZE as BS,
-  BUTTON_NAME as BN,
-  URL as U,
-} from '../../../../utils/const';
-import AddIcon from '@material-ui/icons/Add';
-import { useRecoilState, useSetRecoilState } from 'recoil';
-import {
-  milestoneAddInputState,
-  milestoneAddState,
-} from '../../../../store/Recoil';
+import MilestoneAddHeader from './MilestoneAddHeader';
+import MilestoneAddName from './MilestoneAddName';
+import MilestoneAddDescription from './MilestoneAddDescription';
+import MilestoneAddDueDate from './MilestoneAddDueDate';
+import MilestoneAddCompleteButton from './MilestoneAddCompleteButton';
 
 const MilestoneAdd = (): JSX.Element => {
-  const setMilestoneAdd = useSetRecoilState(milestoneAddState);
-  const userToken = localStorage.getItem('token');
-
-  const handleClickButton = () => {
-    getPost(U.MILESTONE, userToken, milestoneAddInput);
-    setMilestoneAdd((prev) => !prev);
-  };
-
-  const [milestoneAddInput, setMilestoneAddInput] = useRecoilState(
-    milestoneAddInputState
-  );
-
-  const handleChangeInputTitle = (
-    e: React.ChangeEvent<HTMLInputElement>
-  ): void =>
-    setMilestoneAddInput({
-      ...milestoneAddInput,
-      title: e.target.value,
-    });
-  const handleChangeInputDescription = (
-    e: React.ChangeEvent<HTMLInputElement>
-  ): void =>
-    setMilestoneAddInput({
-      ...milestoneAddInput,
-      description: e.target.value,
-    });
-
   return (
     <MilestoneAddStyle>
-      <MilestoneAddHeader>
-        <TextBox>
-          <TextGroup type={T.LARGE} content={M.ADD} color="#14142B" />
-        </TextBox>
-      </MilestoneAddHeader>
+      <MilestoneAddHeader />
       <MilestoneAddCell>
         <InputContainer>
           <AddUpper>
-            <InputBox>
-              <InputGroup
-                variant="outlined"
-                name={M.NAME}
-                type={T.LARGE}
-                onChange={handleChangeInputTitle}
-              />
-            </InputBox>
-            <InputBox>
-              <InputGroup variant="outlined" name={M.DUE} type={T.LARGE} />
-            </InputBox>
+            <MilestoneAddName />
+            <MilestoneAddDueDate />
           </AddUpper>
           <AddLower>
-            <InputBox>
-              <InputGroup
-                variant="outlined"
-                name={M.DESC}
-                type={T.LARGE}
-                onChange={handleChangeInputDescription}
-              />
-            </InputBox>
+            <MilestoneAddDescription />
           </AddLower>
         </InputContainer>
       </MilestoneAddCell>
       <ButtonContainer>
-        <ButtonBox onClick={handleClickButton}>
-          <ButtonGroup
-            type={BS.SMALL_FILL}
-            name={BN.COMPLETE}
-            icon={<AddIcon style={{ fontSize: 16 }} />}
-          />
-        </ButtonBox>
+        <MilestoneAddCompleteButton />
       </ButtonContainer>
     </MilestoneAddStyle>
   );
@@ -98,13 +33,6 @@ export default MilestoneAdd;
 
 const MilestoneAddStyle = styled.div`
   margin: 20px 0px;
-`;
-
-const MilestoneAddHeader = styled(S.IssueTableHeader)`
-  background: #fff;
-  border-bottom: none;
-  padding-bottom: 30px;
-  height: fit-content;
 `;
 
 const MilestoneAddCell = styled(S.IssueCell)`
@@ -122,35 +50,8 @@ const ButtonContainer = styled(S.IssueCell)`
   padding: 20px;
 `;
 
-const TextBox = styled.div`
-  margin-left: 20px;
-  margin-top: 20px;
-`;
-
-const InputBox = styled.div`
-  padding: 10px 20px;
-  width: 100%;
-
-  div {
-    width: 100%;
-  }
-
-  input {
-    background: #eff0f6;
-    border-radius: 16px;
-  }
-
-  fieldset {
-    border-radius: 16px;
-  }
-`;
-
 const InputContainer = styled.div`
   width: 100%;
-`;
-
-const ButtonBox = styled.div`
-  display: flex;
 `;
 
 const AddUpper = styled.div`

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneEdit/MilestoneEditCancelButton.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneEdit/MilestoneEditCancelButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useSetRecoilState } from 'recoil';
+import CloseIcon from '@material-ui/icons/Close';
+import ButtonGroup from '../../../common/group/ButtonGroup';
+import { milestoneEditIdState } from '../../../../store/Recoil';
+import { BUTTON_NAME as BN, BUTTON_SIZE as BS } from '../../../../utils/const';
+
+const MilestoneEditCancelButton = (): JSX.Element => {
+  const setMilestoneEditId = useSetRecoilState(milestoneEditIdState);
+
+  const handleClickButton = () => setMilestoneEditId(0);
+
+  return (
+    <ButtonBox onClick={handleClickButton}>
+      <ButtonGroup
+        type={BS.SMALL_FILL}
+        name={BN.CANCEL}
+        icon={<CloseIcon style={{ fontSize: 16 }} />}
+      />
+    </ButtonBox>
+  );
+};
+export default MilestoneEditCancelButton;
+
+const ButtonBox = styled.div`
+  display: flex;
+`;

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneEdit/MilestoneEditCompleteButton.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneEdit/MilestoneEditCompleteButton.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import styled from 'styled-components';
+import ButtonGroup from '../../../common/group/ButtonGroup';
+import { getPut } from '../../../../utils/restAPI';
+import {
+  BUTTON_SIZE as BS,
+  BUTTON_NAME as BN,
+  URL as U,
+} from '../../../../utils/const';
+import AddIcon from '@material-ui/icons/Add';
+import { useRecoilValue, useRecoilState } from 'recoil';
+import {
+  milestoneEditIdState,
+  milestoneEditInputState,
+} from '../../../../store/Recoil';
+
+const MilestoneEditCompleteButton = (): JSX.Element => {
+  const [milestoneEditId, setMilestoneEditId] =
+    useRecoilState(milestoneEditIdState);
+  const milestoneEditInput = useRecoilValue(milestoneEditInputState);
+  const userToken = localStorage.getItem('token');
+  const milestoneEditUrl = U.MILESTONE + '/' + milestoneEditId;
+
+  const handleClickCompleteButton = () => {
+    getPut(milestoneEditUrl, userToken, milestoneEditInput);
+    setMilestoneEditId(0);
+  };
+
+  return (
+    <ButtonBox onClick={handleClickCompleteButton}>
+      <ButtonGroup
+        type={BS.SMALL_FILL}
+        name={BN.COMPLETE}
+        icon={<AddIcon style={{ fontSize: 16 }} />}
+      />
+    </ButtonBox>
+  );
+};
+
+export default MilestoneEditCompleteButton;
+
+const ButtonBox = styled.div`
+  display: flex;
+  margin-left: 8px;
+`;

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneEdit/MilestoneEditDescription.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneEdit/MilestoneEditDescription.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
+import { TYPE as T, MILESTONE as M } from '../../../../utils/const';
+import { milestoneEditInputState } from '../../../../store/Recoil';
+import InputGroup from '../../../common/group/InputGroup';
+
+const MilestoneEditDescription = (): JSX.Element => {
+  const [milestoneEdit, setMilestoneEdit] = useRecoilState(
+    milestoneEditInputState
+  );
+  const { description } = milestoneEdit;
+
+  const handleChangeInputDescription = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ): void =>
+    setMilestoneEdit({
+      ...milestoneEdit,
+      description: e.target.value,
+    });
+
+  return (
+    <InputBox>
+      <InputGroup
+        variant="outlined"
+        name={M.DESC}
+        type={T.LARGE}
+        onChange={handleChangeInputDescription}
+        value={description}
+      />
+    </InputBox>
+  );
+};
+
+export default MilestoneEditDescription;
+
+const InputBox = styled.div`
+  padding: 10px 20px;
+  width: 100%;
+
+  div {
+    width: 100%;
+  }
+
+  input {
+    background: #eff0f6;
+    border-radius: 16px;
+  }
+
+  fieldset {
+    border-radius: 16px;
+  }
+`;

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneEdit/MilestoneEditDueDate.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneEdit/MilestoneEditDueDate.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import styled from 'styled-components';
+import { TYPE as T, MILESTONE as M } from '../../../../utils/const';
+import InputGroup from '../../../common/group/InputGroup';
+
+const MilestoneEditDueDate = (): JSX.Element => {
+  return (
+    <InputBox>
+      <InputGroup variant="outlined" name={M.DUE} type={T.LARGE} />
+    </InputBox>
+  );
+};
+
+export default MilestoneEditDueDate;
+
+const InputBox = styled.div`
+  padding: 10px 20px;
+  width: 100%;
+
+  div {
+    width: 100%;
+  }
+
+  input {
+    background: #eff0f6;
+    border-radius: 16px;
+  }
+
+  fieldset {
+    border-radius: 16px;
+  }
+`;

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneEdit/MilestoneEditHeader.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneEdit/MilestoneEditHeader.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import styled from 'styled-components';
+import TextGroup from '../../../common/group/TextGroup';
+import { TYPE as T, MILESTONE as M } from '../../../../utils/const';
+import { Issue as S } from '../../../styles/CommonStyles';
+
+const MilestoneEditHeader = (): JSX.Element => {
+  return (
+    <MilestoneEditHeaderStyle>
+      <TextBox>
+        <TextGroup type={T.LARGE} content={M.EDIT} color="#14142B" />
+      </TextBox>
+    </MilestoneEditHeaderStyle>
+  );
+};
+
+export default MilestoneEditHeader;
+
+const MilestoneEditHeaderStyle = styled(S.IssueTableHeader)`
+  background: #fff;
+  height: fit-content;
+  padding-bottom: 30px;
+  border-top: none;
+  border-bottom: none;
+  border-radius: 0;
+`;
+
+const TextBox = styled.div`
+  margin-left: 20px;
+  margin-top: 20px;
+`;

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneEdit/MilestoneEditName.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneEdit/MilestoneEditName.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
+import { TYPE as T, MILESTONE as M } from '../../../../utils/const';
+import { milestoneEditInputState } from '../../../../store/Recoil';
+import InputGroup from '../../../common/group/InputGroup';
+
+const MilestoneEditName = (): JSX.Element => {
+  const [milestoneEdit, setMilestoneEdit] = useRecoilState(
+    milestoneEditInputState
+  );
+  const { title } = milestoneEdit;
+
+  const handleChangeInputTitle = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ): void =>
+    setMilestoneEdit({
+      ...milestoneEdit,
+      title: e.target.value,
+    });
+
+  return (
+    <InputBox>
+      <InputGroup
+        variant="outlined"
+        name={M.NAME}
+        type={T.LARGE}
+        onChange={handleChangeInputTitle}
+        value={title}
+      />
+    </InputBox>
+  );
+};
+
+export default MilestoneEditName;
+
+const InputBox = styled.div`
+  padding: 10px 20px;
+  width: 100%;
+
+  div {
+    width: 100%;
+  }
+
+  input {
+    background: #eff0f6;
+    border-radius: 16px;
+  }
+
+  fieldset {
+    border-radius: 16px;
+  }
+`;

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneEdit/index.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneEdit/index.tsx
@@ -1,56 +1,31 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Issue as S } from '../../../styles/CommonStyles';
-import TextGroup from '../../../common/group/TextGroup';
-import InputGroup from '../../../common/group/InputGroup';
-import ButtonGroup from '../../../common/group/ButtonGroup';
-
-import {
-  TYPE as T,
-  MILESTONE as M,
-  BUTTON_SIZE as BS,
-  BUTTON_NAME as BN,
-} from '../../../../utils/const';
-import AddIcon from '@material-ui/icons/Add';
-import { useSetRecoilState } from 'recoil';
-import { milestoneAddState } from '../../../../store/Recoil';
+import MilestoneEditHeader from './MilestoneEditHeader';
+import MilestoneEditName from './MilestoneEditName';
+import MilestoneEditDescription from './MilestoneEditDescription';
+import MilestoneEditDueDate from './MilestoneEditDueDate';
+import MilestoneEditCompleteButton from './MilestoneEditCompleteButton';
+import MilestoneEditCancelButton from './MilestoneEditCancelButton';
 
 const MilestoneEdit = (): JSX.Element => {
-  const setMilestoneAdd = useSetRecoilState(milestoneAddState);
-  const handleClickButton = () => setMilestoneAdd((prev) => !prev);
-
   return (
     <MilestoneEditStyle>
-      <MilestoneEditHeader>
-        <TextBox>
-          <TextGroup type={T.LARGE} content={M.ADD} color="#14142B" />
-        </TextBox>
-      </MilestoneEditHeader>
+      <MilestoneEditHeader />
       <MilestoneEditCell>
         <InputContainer>
-          <AddUpper>
-            <InputBox>
-              <InputGroup variant="outlined" name={M.NAME} type={T.LARGE} />
-            </InputBox>
-            <InputBox>
-              <InputGroup variant="outlined" name={M.DUE} type={T.LARGE} />
-            </InputBox>
-          </AddUpper>
-          <AddLower>
-            <InputBox>
-              <InputGroup variant="outlined" name={M.DESC} type={T.LARGE} />
-            </InputBox>
-          </AddLower>
+          <EditUpper>
+            <MilestoneEditName />
+            <MilestoneEditDueDate />
+          </EditUpper>
+          <EditLower>
+            <MilestoneEditDescription />
+          </EditLower>
         </InputContainer>
       </MilestoneEditCell>
       <ButtonContainer>
-        <ButtonBox onClick={handleClickButton}>
-          <ButtonGroup
-            type={BS.SMALL_FILL}
-            name={BN.COMPLETE}
-            icon={<AddIcon style={{ fontSize: 16 }} />}
-          />
-        </ButtonBox>
+        <MilestoneEditCancelButton />
+        <MilestoneEditCompleteButton />
       </ButtonContainer>
     </MilestoneEditStyle>
   );
@@ -58,16 +33,7 @@ const MilestoneEdit = (): JSX.Element => {
 
 export default MilestoneEdit;
 
-const MilestoneEditStyle = styled.div`
-  margin: 20px 0px;
-`;
-
-const MilestoneEditHeader = styled(S.IssueTableHeader)`
-  background: #fff;
-  border-bottom: none;
-  padding-bottom: 30px;
-  height: fit-content;
-`;
+const MilestoneEditStyle = styled.div``;
 
 const MilestoneEditCell = styled(S.IssueCell)`
   justify-content: center;
@@ -82,28 +48,9 @@ const ButtonContainer = styled(S.IssueCell)`
   justify-content: flex-end;
   height: fit-content;
   padding: 20px;
-`;
 
-const TextBox = styled.div`
-  margin-left: 20px;
-  margin-top: 20px;
-`;
-
-const InputBox = styled.div`
-  padding: 10px 20px;
-  width: 100%;
-
-  div {
-    width: 100%;
-  }
-
-  input {
-    background: #eff0f6;
-    border-radius: 16px;
-  }
-
-  fieldset {
-    border-radius: 16px;
+  :last-child {
+    border-radius: 0;
   }
 `;
 
@@ -111,13 +58,9 @@ const InputContainer = styled.div`
   width: 100%;
 `;
 
-const ButtonBox = styled.div`
-  display: flex;
-`;
-
-const AddUpper = styled.div`
+const EditUpper = styled.div`
   display: flex;
   width: 100%;
 `;
 
-const AddLower = styled.div``;
+const EditLower = styled.div``;

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneNav/index.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneNav/index.tsx
@@ -17,7 +17,6 @@ const MilestoneNav: FC = () => {
   const [milestoneAdd, setMilestoneAdd] = useRecoilState(milestoneAddState);
   const milestoneList = useFetch(U.MILESTONE, [milestoneAdd]);
   const handleClickbutton = () => setMilestoneAdd((prev) => !prev);
-  console.log(milestoneList);
 
   return (
     <MilestoneNavDiv>

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneNav/index.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneNav/index.tsx
@@ -1,23 +1,29 @@
 import React, { FC } from 'react';
 import styled from 'styled-components';
-import { BUTTON_SIZE as BS, BUTTON_NAME as BN } from '../../../../utils/const';
+import {
+  BUTTON_SIZE as BS,
+  BUTTON_NAME as BN,
+  URL as U,
+} from '../../../../utils/const';
 import ButtonGroup from '../../../common/group/ButtonGroup';
 import TabGroup from '../../../common/group/TabGroup';
 import AddIcon from '@material-ui/icons/Add';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 import { useRecoilState } from 'recoil';
 import { milestoneAddState } from '../../../../store/Recoil';
+import useFetch from '../../../../utils/useFetch';
 
 const MilestoneNav: FC = () => {
   const [milestoneAdd, setMilestoneAdd] = useRecoilState(milestoneAddState);
-
+  const milestoneList = useFetch(U.MILESTONE, [milestoneAdd]);
   const handleClickbutton = () => setMilestoneAdd((prev) => !prev);
+  console.log(milestoneList);
 
   return (
     <MilestoneNavDiv>
       <MilestoneNavContainer>
         <TabBox>
-          <TabGroup />
+          <TabGroup milestoneCount={milestoneList?.milestones.length} />
         </TabBox>
         {milestoneAdd ? (
           <ButtonBox onClick={handleClickbutton}>

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/MilestoneCell.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/MilestoneCell.tsx
@@ -1,136 +1,70 @@
 import React from 'react';
 import styled from 'styled-components';
-import { v4 as uuidv4 } from 'uuid';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
-import FlagTwoToneIcon from '@material-ui/icons/FlagTwoTone';
-import CalendarTodayTwoToneIcon from '@material-ui/icons/CalendarTodayTwoTone';
 import TextGroup from '../../../common/group/TextGroup';
-import CommonButton from '../../../common/CommonButton';
 import ProgressBar from '../../../common/ProgressBar';
-import {
-  getDate,
-  getIssueCount,
-  getProgressRate,
-} from '../../../../utils/util';
-import {
-  milestoneAddState,
-  milestoneEditState,
-} from '../../../../store/Recoil';
-import useFetch from '../../../../utils/useFetch';
+import { getIssueCount, getProgressRate } from '../../../../utils/util';
 import { MilestoneDataProps } from '../../../../utils/types/commonTypes';
 import { Issue as S } from '../../../styles/CommonStyles';
-import { TYPE as T, URL as U } from '../../../../utils/const';
+import { TYPE as T } from '../../../../utils/const';
 import MilestoneEditButton from './MilestoneEditButton';
 import MilestoneCloseButton from './MilestoneCloseButton';
 import MilestoneDeleteButton from './MilestoneDeleteButton';
+import MilestoneTitle from './MilestoneTitle';
+import MilestoneDueDate from './MilestoneDueDate';
+import MilestoneDescription from './MilestoneDescription';
+import MilestoneProgressRate from './MilestoneProgressRate';
 
-const MilestoneCell = (): JSX.Element => {
-  const milestoneAdd = useRecoilValue(milestoneAddState);
-  const milestone = useFetch(U.MILESTONE, [milestoneAdd]);
-  const setMilestoneEdit = useSetRecoilState(milestoneEditState);
-  const milestones = milestone?.milestones;
+const MilestoneCell = ({
+  milestone,
+}: {
+  milestone: MilestoneDataProps;
+}): JSX.Element => {
+  const { id, issues, milestoneInfo } = milestone;
 
-  const handleClickEditButton = (e: React.MouseEvent<HTMLInputElement>) => {
-    setMilestoneEdit((prev) => !prev);
-  };
-
-  const handleClickDeleteButton = () => {
-    console.log('delete');
-  };
+  const openIssue = getIssueCount(issues, 'OPEN');
+  const closeIssue = getIssueCount(issues, 'CLOSE');
+  const progressRate = getProgressRate(openIssue, closeIssue);
 
   return (
-    <>
-      {milestones?.map((milestone: MilestoneDataProps) => {
-        const openIssue = getIssueCount(milestone.issues, 'OPEN');
-        const closeIssue = getIssueCount(milestone.issues, 'CLOSE');
-        const progressRate = getProgressRate(openIssue, closeIssue);
-
-        return (
-          <MilestoneCellStyle
-            key={uuidv4()}
-            id={`${milestone.id}`}
-            onClick={handleClickEditButton}
-          >
-            <LeftBox>
-              <LeftUpper>
-                <CommonButton
-                  icon={
-                    <FlagTwoToneIcon
-                      style={{
-                        width: '16px',
-                        height: '16px',
-                        color: '#007AFF',
-                      }}
-                    />
-                  }
-                  text={
-                    <TextGroup
-                      type={T.MEDIUM}
-                      content={milestone.milestoneInfo.title}
-                      color="#222"
-                    />
-                  }
-                />
-
-                {milestone.milestoneInfo.dueDate && (
-                  <CommonButton
-                    icon={
-                      <CalendarTodayTwoToneIcon
-                        style={{ fontSize: 'small', color: '#6E7191' }}
-                      />
-                    }
-                    text={
-                      <TextGroup
-                        type={T.SMALL}
-                        content={getDate(milestone.milestoneInfo.dueDate)}
-                        color="#6E7191"
-                      />
-                    }
-                  />
-                )}
-              </LeftUpper>
-              <LeftLower>
-                <TextGroup
-                  type={T.SMALL}
-                  content={milestone.milestoneInfo.description}
-                  color="#6E7191"
-                />
-              </LeftLower>
-            </LeftBox>
-            <RightBox>
-              <RightUpper>
-                <MilestoneCloseButton />
-                <MilestoneEditButton />
-                <MilestoneDeleteButton />
-              </RightUpper>
-              <RightCenter>
-                <ProgressBar value={progressRate} />
-              </RightCenter>
-              <RightLower>
-                <TextGroup
-                  type={T.SMALL}
-                  content={`${progressRate}%`}
-                  color="#6E7191"
-                />
-                <IssueButtonBox>
-                  <TextGroup
-                    type={T.SMALL}
-                    content={`열린이슈(${openIssue})`}
-                    color="#6E7191"
-                  />
-                  &nbsp;
-                  <TextGroup
-                    type={T.SMALL}
-                    content={`닫힌이슈(${closeIssue})`}
-                    color="#6E7191"
-                  />
-                </IssueButtonBox>
-              </RightLower>
-            </RightBox>
-          </MilestoneCellStyle>
-        );
-      })}
-    </>
+    <MilestoneCellStyle>
+      <LeftBox>
+        <LeftUpper>
+          <MilestoneTitle title={milestoneInfo.title} />
+          <MilestoneDueDate dueDate={milestoneInfo.dueDate} />
+        </LeftUpper>
+        <LeftLower>
+          <MilestoneDescription description={milestoneInfo.description} />
+        </LeftLower>
+      </LeftBox>
+      <RightBox>
+        <RightUpper>
+          <MilestoneCloseButton {...{ id }} />
+          <MilestoneEditButton {...{ id }} />
+          <MilestoneDeleteButton {...{ id }} />
+        </RightUpper>
+        <RightCenter>
+          <ProgressBar value={progressRate} />
+        </RightCenter>
+        <RightLower>
+          <MilestoneProgressRate progressRate={progressRate} />
+          <IssueButtonBox>
+            {/* 열린이슈 */}
+            <TextGroup
+              type={T.SMALL}
+              content={`열린이슈(${openIssue})`}
+              color="#6E7191"
+            />
+            &nbsp;
+            {/* 닫힌이슈 */}
+            <TextGroup
+              type={T.SMALL}
+              content={`닫힌이슈(${closeIssue})`}
+              color="#6E7191"
+            />
+          </IssueButtonBox>
+        </RightLower>
+      </RightBox>
+    </MilestoneCellStyle>
   );
 };
 

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/MilestoneCloseButton.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/MilestoneCloseButton.tsx
@@ -4,7 +4,7 @@ import ClosedIconGroup from '../../../common/group/ClosedIconGroup';
 import TextGroup from '../../../common/group/TextGroup';
 import { TYPE as T, BUTTON_NAME as BN } from '../../../../utils/const';
 
-const MilestoneCloseButton = (): JSX.Element => {
+const MilestoneCloseButton = ({ id }: { id: number }): JSX.Element => {
   const handleClickCloseButton = () => {
     console.log('Close');
   };
@@ -13,6 +13,7 @@ const MilestoneCloseButton = (): JSX.Element => {
       icon={<ClosedIconGroup type={'disabled'} />}
       text={<TextGroup type={T.SMALL} content={BN.CLOSE} color="#6E7191" />}
       onClick={handleClickCloseButton}
+      id={id}
     />
   );
 };

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/MilestoneDeleteButton.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/MilestoneDeleteButton.tsx
@@ -2,11 +2,19 @@ import React from 'react';
 import CommonButton from '../../../common/CommonButton';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 import TextGroup from '../../../common/group/TextGroup';
-import { TYPE as T, BUTTON_NAME as BN } from '../../../../utils/const';
+import {
+  TYPE as T,
+  BUTTON_NAME as BN,
+  URL as U,
+} from '../../../../utils/const';
+import { getDelete } from '../../../../utils/restAPI';
 
-const MilestoneDeleteButton = (): JSX.Element => {
-  const handleClickDeleteButton = () => {
-    console.log('Delete');
+const MilestoneDeleteButton = ({ id }: { id: number }): JSX.Element => {
+  const userToken = localStorage.getItem('token');
+
+  const handleClickDeleteButton = (e: React.MouseEvent<HTMLInputElement>) => {
+    const issueDeleteUrl = U.MILESTONE + '/' + e.currentTarget.id;
+    getDelete(issueDeleteUrl, userToken);
   };
 
   return (
@@ -14,6 +22,7 @@ const MilestoneDeleteButton = (): JSX.Element => {
       icon={<DeleteOutlineIcon style={{ color: '#FF3B30', fontSize: 16 }} />}
       text={<TextGroup type={T.SMALL} content={BN.DELETE} color="#FF3B30" />}
       onClick={handleClickDeleteButton}
+      id={id}
     />
   );
 };

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/MilestoneDescription.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/MilestoneDescription.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import TextGroup from '../../../common/group/TextGroup';
+import { TYPE as T } from '../../../../utils/const';
+
+const MilestoneDescription = ({
+  description,
+}: {
+  description: string;
+}): JSX.Element => {
+  return <TextGroup type={T.SMALL} content={description} color="#6E7191" />;
+};
+
+export default MilestoneDescription;

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/MilestoneDueDate.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/MilestoneDueDate.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import CommonButton from '../../../common/CommonButton';
+import TextGroup from '../../../common/group/TextGroup';
+import { TYPE as T } from '../../../../utils/const';
+import CalendarTodayTwoToneIcon from '@material-ui/icons/CalendarTodayTwoTone';
+import { getDate } from '../../../../utils/util';
+
+const MilestoneDueDate = ({ dueDate }: { dueDate: string }): JSX.Element => {
+  return (
+    <>
+      {dueDate && (
+        <CommonButton
+          icon={
+            <CalendarTodayTwoToneIcon
+              style={{ fontSize: 'small', color: '#6E7191' }}
+            />
+          }
+          text={
+            <TextGroup
+              type={T.SMALL}
+              content={getDate(dueDate)}
+              color="#6E7191"
+            />
+          }
+        />
+      )}
+    </>
+  );
+};
+
+export default MilestoneDueDate;

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/MilestoneEditButton.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/MilestoneEditButton.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
+import { useSetRecoilState } from 'recoil';
 import CommonButton from '../../../common/CommonButton';
 import EditIcon from '@material-ui/icons/Edit';
 import TextGroup from '../../../common/group/TextGroup';
+import { milestoneEditIdState } from '../../../../store/Recoil';
 import { TYPE as T, BUTTON_NAME as BN } from '../../../../utils/const';
 
-const MilestoneEditButton = (): JSX.Element => {
-  const handleClickEditButton = () => {
-    console.log('edit');
+const MilestoneEditButton = ({ id }: { id: number }): JSX.Element => {
+  const setMilestoneEditId = useSetRecoilState(milestoneEditIdState);
+  const handleClickEditButton = (e: React.MouseEvent<HTMLInputElement>) => {
+    setMilestoneEditId((prev) => (prev === 0 ? +e.currentTarget.id : 0));
   };
 
   return (
@@ -14,7 +17,7 @@ const MilestoneEditButton = (): JSX.Element => {
       icon={<EditIcon style={{ color: '#6E7191', fontSize: 16 }} />}
       text={<TextGroup type={T.SMALL} content={BN.EDIT} color="#6E7191" />}
       onClick={handleClickEditButton}
-      id={1}
+      id={id}
     />
   );
 };

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/MilestoneProgressRate.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/MilestoneProgressRate.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import TextGroup from '../../../common/group/TextGroup';
+import { TYPE as T } from '../../../../utils/const';
+
+const MilestoneProgressRate = ({
+  progressRate,
+}: {
+  progressRate: number;
+}): JSX.Element => {
+  return (
+    <TextGroup type={T.SMALL} content={`${progressRate}%`} color="#6E7191" />
+  );
+};
+
+export default MilestoneProgressRate;

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/MilestoneTitle.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/MilestoneTitle.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import CommonButton from '../../../common/CommonButton';
+import FlagTwoToneIcon from '@material-ui/icons/FlagTwoTone';
+import TextGroup from '../../../common/group/TextGroup';
+import { TYPE as T } from '../../../../utils/const';
+
+const MilestoneTitle = ({ title }: { title: string }): JSX.Element => {
+  return (
+    <CommonButton
+      icon={
+        <FlagTwoToneIcon
+          style={{
+            width: '16px',
+            height: '16px',
+            color: '#007AFF',
+          }}
+        />
+      }
+      text={<TextGroup type={T.MEDIUM} content={title} color="#222" />}
+    />
+  );
+};
+
+export default MilestoneTitle;

--- a/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/index.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/MilestoneTable/index.tsx
@@ -1,17 +1,42 @@
 import React from 'react';
-import styled from 'styled-components';
 import MilestoneTableHeader from './MilestoneTableHeader';
 import MilestoneCell from './MilestoneCell';
+import {
+  milestoneEditIdState,
+  milestoneAddState,
+  milestoneEditInputState,
+} from '../../../../store/Recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import useFetch from '../../../../utils/useFetch';
+import { URL as U } from '../../../../utils/const';
+import MilestoneEdit from '../MilestoneEdit';
+import { MilestoneDataProps } from '../../../../utils/types/commonTypes';
+import { v4 as uuidv4 } from 'uuid';
 
 const MilestoneTable = (): JSX.Element => {
+  const milestoneAdd = useRecoilValue(milestoneAddState);
+  const milestoneEditId = useRecoilValue(milestoneEditIdState);
+  const setMilestoneEditInput = useSetRecoilState(milestoneEditInputState);
+
+  const milestoneList = useFetch(U.MILESTONE, [milestoneAdd]);
+  const milestones = milestoneList?.milestones;
+
   return (
-    <IssueTableContainer>
+    <>
       <MilestoneTableHeader />
-      <MilestoneCell />
-    </IssueTableContainer>
+      {milestones?.map((milestone: MilestoneDataProps) => {
+        milestoneEditId === milestone.id &&
+          setMilestoneEditInput(milestone.milestoneInfo);
+
+        return (
+          <React.Fragment key={uuidv4()}>
+            <MilestoneCell {...{ milestone }} />
+            {milestoneEditId === milestone.id && <MilestoneEdit />}
+          </React.Fragment>
+        );
+      })}
+    </>
   );
 };
 
 export default MilestoneTable;
-
-const IssueTableContainer = styled.div``;

--- a/frontend/issue-cracker/src/components/layout/Milestone/index.tsx
+++ b/frontend/issue-cracker/src/components/layout/Milestone/index.tsx
@@ -8,6 +8,7 @@ import MilestoneTable from './MilestoneTable';
 
 const MilestoneList = (): JSX.Element => {
   const milestoneAdd = useRecoilValue(milestoneAddState);
+
   return (
     <MilestoneistStyle>
       <MilestoneNav />

--- a/frontend/issue-cracker/src/store/Recoil.tsx
+++ b/frontend/issue-cracker/src/store/Recoil.tsx
@@ -1,5 +1,9 @@
 import { atom, selector } from 'recoil';
-import { dropCheckStateProps, Milestones } from '../utils/types/commonTypes';
+import {
+  dropCheckStateProps,
+  MilestoneProps,
+  Milestones,
+} from '../utils/types/commonTypes';
 import { URL as U } from '../utils/const';
 
 // Login
@@ -81,6 +85,11 @@ export const milestoneListState = atom<Milestones | null>({
   default: null,
 });
 
+export const milestoneEditIdState = atom({
+  key: 'milestoneEditIdState',
+  default: 0,
+});
+
 interface MilestoneAddInputProps {
   title: string;
   description: string;
@@ -91,6 +100,17 @@ export const milestoneAddInputState = atom<MilestoneAddInputProps>({
   default: {
     title: '',
     description: '',
+  },
+});
+
+export const milestoneEditInputState = atom<MilestoneProps>({
+  key: 'milestoneEditInputState',
+  default: {
+    id: 0,
+    title: '',
+    description: '',
+    dueDate: '',
+    status: '',
   },
 });
 

--- a/frontend/issue-cracker/src/utils/const.ts
+++ b/frontend/issue-cracker/src/utils/const.ts
@@ -103,6 +103,7 @@ export const LABEL = {
 export const MILESTONE = {
   TITLE: '마일스톤 제목',
   ADD: '새로운 마일스톤 추가',
+  EDIT: '마일스톤 수정',
   NAME: '마일스톤 이름',
   DESC: '설명(선택)',
   DUE: '완료일(선택) ex. YYYY-MM-DD',


### PR DESCRIPTION
## 구현결과

![스크린샷 2021-07-09 01 44 25](https://user-images.githubusercontent.com/70361152/124960525-62d78480-e057-11eb-8168-2527ba3dde0d.png)

## 추가된 기능
- [x] 마일스톤 편집
- [x] 마일스톤 삭제
- [x] 탭그룹 버튼 카운터 표시(현재는 마일스톤만...)

## 필요한 기능
- [ ] 데이터 업데이트시 리렌더링
- [ ] 탭그룹 버튼 카운터 표시
- [ ] 완료일 추가, 편집, 삭제 기능