### PR TITLE
feat: 쿼리 조회 실패시 exception handling

### DIFF
--- a/backend/server/src/main/java/com/issuetracker/controller/ExceptionController.java
+++ b/backend/server/src/main/java/com/issuetracker/controller/ExceptionController.java
@@ -6,6 +6,7 @@ import com.issuetracker.exception.JwtException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
+import org.springframework.dao.DataAccessException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -13,12 +14,11 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
 import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.http.HttpStatus.*;
 
 @Order(HIGHEST_PRECEDENCE)
 @ControllerAdvice
@@ -31,7 +31,7 @@ public class ExceptionController {
     public MessagesResponse handleJwtException(JwtException e) {
         String message = e.getMessage();
         logger.error(message);
-        return new MessagesResponse(Arrays.asList(message));
+        return new MessagesResponse(Collections.singletonList(message));
     }
 
     @ResponseStatus(UNAUTHORIZED)
@@ -40,7 +40,7 @@ public class ExceptionController {
     public MessagesResponse handleAuthenticationException(AuthenticationException e) {
         String message = e.getMessage();
         logger.error(message);
-        return new MessagesResponse(Arrays.asList(message));
+        return new MessagesResponse(Collections.singletonList(message));
     }
 
     @ResponseStatus(BAD_REQUEST)
@@ -50,5 +50,12 @@ public class ExceptionController {
         return new MessagesResponse(e.getBindingResult().getFieldErrors()
                 .stream().map(FieldError::getDefaultMessage)
                 .collect(Collectors.toList()));
+    }
+
+    @ResponseStatus(NOT_FOUND)
+    @ResponseBody
+    @ExceptionHandler(DataAccessException.class)
+    public MessagesResponse handleDataAccessException(DataAccessException e) {
+        return new MessagesResponse(Collections.singletonList(e.getMessage()));
     }
 }


### PR DESCRIPTION
queryForObject 를 타고 들어가보니, 내부적으로 DataAccessException 예외를 던져 주는 구문이 있어서,
추가적인 커스텀 예외는 만들지 않았습니다.

```java
@Override
	@Nullable
	public <T> T queryForObject(String sql, Map<String, ?> paramMap, RowMapper<T>rowMapper)
			throws DataAccessException {

		return queryForObject(sql, new MapSqlParameterSource(paramMap), rowMapper);
	}
```

현재 서버에 없는 자원을 요청할 경우 404 상태코드가 출력 되며,
![image](https://user-images.githubusercontent.com/73760074/125027432-30fb0800-e0c1-11eb-9bfc-a4483476d31e.png)

잘못된 경로를 요청할 경우 400 상태코드가 응답됩니다.

![image](https://user-images.githubusercontent.com/73760074/125027507-4e2fd680-e0c1-11eb-9dcf-02e727f3aeaf.png)


