### PR TITLE
만료된 서버의 BASE_URL 을 localhost 로 수정

### DIFF
--- a/frontend/issue-cracker/src/utils/const.ts
+++ b/frontend/issue-cracker/src/utils/const.ts
@@ -15,13 +15,13 @@ export const LOGO_TITLE = 'Issue Cracker..🍪';
 // const CLIENT_ID = DEVELOPE_ID;
 
 const DEVELOPE = {
-  BASE_URL: 'http://localhost:3000',
+  BASE_URL: 'http://localhost:8080',
   CLIENT_ID: 'bd67de79012efe833a1e',
   API_URL: '/api/web/localhost/auth',
 };
 
 const DEPLOY = {
-  BASE_URL: 'http://issue-tracker.pyro-squad.com',
+  BASE_URL: 'http://localhost:8080',
   CLIENT_ID: '2a42dd1b1e2aad1238e9',
   API_URL: '/api/web/localhost/auth',
 };


### PR DESCRIPTION
기존의 Oracle 서버가 폭파되어서, 임시로 localhost 를 사용하도록 수정했습니다.

나중에 서버를 제대로 배포하면, 다시 BASE_URL 을 수정할 생각입니다.

리뷰 승인 없이 바로 머지하겠습니다.