### PR TITLE
API 조회 테스트 작성 리뷰 요청 드립니다.

### DIFF
--- a/backend/server/build.gradle
+++ b/backend/server/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 
     // form-validator
     implementation group: 'org.hibernate', name: 'hibernate-validator', version: '7.0.1.Final'
+
+    testImplementation 'org.mockito:mockito-core:3.11.2'
+    testImplementation 'org.mockito:mockito-junit-jupiter:3.11.2'
 }
 
 test {

--- a/backend/server/build.gradle
+++ b/backend/server/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 
     testImplementation 'org.mockito:mockito-core:3.11.2'
     testImplementation 'org.mockito:mockito-junit-jupiter:3.11.2'
+
+    implementation 'io.rest-assured:rest-assured:3.3.0'
+
 }
 
 test {

--- a/backend/server/src/main/java/com/issuetracker/repository/AssigneeRepository.java
+++ b/backend/server/src/main/java/com/issuetracker/repository/AssigneeRepository.java
@@ -18,7 +18,7 @@ public class AssigneeRepository {
         this.jdbc = jdbc;
     }
 
-    public Assignees getAllIssues() {
+    public Assignees getAllAssignees() {
         return new Assignees(jdbc.query(FIND_ALL_USER, Collections.emptyMap(), (rs, rowNum) -> new Assignee(
                 rs.getString("userId"),
                 rs.getString("name"),

--- a/backend/server/src/main/java/com/issuetracker/service/AssigneeService.java
+++ b/backend/server/src/main/java/com/issuetracker/service/AssigneeService.java
@@ -13,6 +13,6 @@ public class AssigneeService {
     }
 
     public AssigneesResponse getAllIssues() {
-        return AssigneesResponse.from(assigneeRepository.getAllIssues());
+        return AssigneesResponse.from(assigneeRepository.getAllAssignees());
     }
 }

--- a/backend/server/src/test/java/com/issuetracker/controller/web/WebAssigneeControllerIntegrationTest.java
+++ b/backend/server/src/test/java/com/issuetracker/controller/web/WebAssigneeControllerIntegrationTest.java
@@ -1,0 +1,39 @@
+package com.issuetracker.controller.web;
+
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+
+import static io.restassured.RestAssured.get;
+import static org.hamcrest.Matchers.hasItem;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class WebAssigneeControllerIntegrationTest {
+    @LocalServerPort
+    public int port;
+
+    @BeforeEach
+    void setup() {
+        RestAssured.baseURI = "http://localhost";
+        RestAssured.port = port;
+    }
+
+    @Test
+    void 담당자_조회_요청() {
+        get("/api/web/assignees")
+                .then()
+                .statusCode(200);
+    }
+
+    //TODO. init.sql에 정의된 더미 데이터를 기반으로 한 쉽게 깨질 테스트 케이스, JPA 마이그레이션 후 제거 예정
+    @Test
+    void 더미_담당자_목록중_sanhee가_존재한다() {
+        get("/api/web/assignees")
+                .then()
+                .log().ifValidationFails()
+                .assertThat().body("assinees.id", hasItem("sanhee"));
+    }
+}

--- a/backend/server/src/test/java/com/issuetracker/controller/web/WebAssigneeControllerTest.java
+++ b/backend/server/src/test/java/com/issuetracker/controller/web/WebAssigneeControllerTest.java
@@ -1,0 +1,83 @@
+package com.issuetracker.controller.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.issuetracker.domain.Assignee;
+import com.issuetracker.domain.Assignees;
+import com.issuetracker.dto.response.AssigneesResponse;
+import com.issuetracker.service.AssigneeService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@ExtendWith(MockitoExtension.class)
+class WebAssigneeControllerTest {
+
+    private MockMvc mvc;
+
+    @Mock
+    private AssigneeService assigneeService;
+
+    @InjectMocks
+    private WebAssigneeController webAssigneeController;
+
+    private JacksonTester<AssigneesResponse> jsonAssignee;
+
+    @BeforeEach
+    public void setUp() {
+        JacksonTester.initFields(this, new ObjectMapper());
+        mvc = MockMvcBuilders.standaloneSetup(webAssigneeController)
+                .addFilter(new CharacterEncodingFilter(StandardCharsets.UTF_8.name(), true))
+                .build();
+    }
+
+    @Test
+    @DisplayName("이슈트래커에 등록된 모든 유저 목록을 가져올 수 있다.")
+    public void getAllIssues() throws Exception {
+
+        // given
+        Assignees assignees = new Assignees(
+                Arrays.asList(
+                        new Assignee("testId", "테스트 계정", "테스트 이미지 주소"),
+                        new Assignee("testId2", "테스트 계정2", "테스트 이미지 주소2"),
+                        new Assignee("testId3", "테스트 계정3", "테스트 이미지 주소3")
+                )
+        );
+
+        AssigneesResponse assigneesResponse = AssigneesResponse.from(assignees);
+        AssigneesResponse expectResponse = AssigneesResponse.from(assignees);
+
+        given(assigneeService.getAllIssues())
+                .willReturn(assigneesResponse);
+
+        // when
+        MockHttpServletResponse response = mvc.perform(
+                get("/api/web/assignees")
+                        .characterEncoding("utf8")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andReturn()
+                .getResponse();
+
+
+        // then
+        //TODO. expect 구문은 가능한 테스트 코드 가독성 때문에 상수로 쓰고 싶은데, 좋은 방법 없을까..빌더?..
+        assertThat(response.getContentAsString()).isEqualTo(jsonAssignee.write(expectResponse).getJson());
+    }
+
+}

--- a/backend/server/src/test/java/com/issuetracker/controller/web/WebIssueControllerIntegrationTest.java
+++ b/backend/server/src/test/java/com/issuetracker/controller/web/WebIssueControllerIntegrationTest.java
@@ -26,4 +26,15 @@ class WebIssueControllerIntegrationTest {
                 .log().ifValidationFails()
                 .statusCode(200);
     }
+
+    //TODO. 쿼리파라미터 필터로 이슈 조회하는 테스트도 추후 작성 해야함.
+
+    //TODO. 배포 환경에서는 99999999번째 이슈가 있을 수도 있다. 상수를 안쓰는 방법을 찾아보자.
+    @Test
+    void 존재하지_않는_이슈_상세_정보_조회() {
+        get("/99999999")
+                .then()
+                .assertThat()
+                .statusCode(404);
+    }
 }

--- a/backend/server/src/test/java/com/issuetracker/controller/web/WebIssueControllerIntegrationTest.java
+++ b/backend/server/src/test/java/com/issuetracker/controller/web/WebIssueControllerIntegrationTest.java
@@ -1,0 +1,29 @@
+package com.issuetracker.controller.web;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+
+import static io.restassured.RestAssured.get;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class WebIssueControllerIntegrationTest {
+    @LocalServerPort
+    public int port;
+
+    @BeforeEach
+    void setup() {
+        RestAssured.baseURI = "http://localhost/api/web/issues";
+        RestAssured.port = port;
+    }
+
+    @Test
+    void 전체_이슈_조회() {
+        get()
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200);
+    }
+}

--- a/backend/server/src/test/java/com/issuetracker/controller/web/WebIssueControllerIntegrationTest.java
+++ b/backend/server/src/test/java/com/issuetracker/controller/web/WebIssueControllerIntegrationTest.java
@@ -37,4 +37,12 @@ class WebIssueControllerIntegrationTest {
                 .assertThat()
                 .statusCode(404);
     }
+
+    @Test
+    void 이슈_생성시_사이드_옵션을_조회_할때_상태코드_200(){
+        get("/form")
+                .then()
+                .assertThat()
+                .statusCode(200);
+    }
 }

--- a/backend/server/src/test/java/com/issuetracker/controller/web/WebIssueControllerIntegrationTest.java
+++ b/backend/server/src/test/java/com/issuetracker/controller/web/WebIssueControllerIntegrationTest.java
@@ -45,4 +45,15 @@ class WebIssueControllerIntegrationTest {
                 .assertThat()
                 .statusCode(200);
     }
+
+    //TODO. 배포 환경에서는 99999999번째 이슈가 있을 수도 있다. 상수를 안쓰는 방법을 찾아보자.
+    //TODO. 존재하지_않는_이슈면 댓글을 조회할 수도 없어야 한다. 하지만 200이 뜨고 있다. :: 고쳐야 하지 않을까?
+    @Test
+    void 특정_이슈의_댓글을_조회하면_상태코드_200(){
+        get("/9999999/comments")
+                .then()
+                .assertThat()
+                .log().ifValidationFails()
+                .statusCode(200);
+    }
 }

--- a/backend/server/src/test/java/com/issuetracker/controller/web/WebLabelControllerIntegrationTest.java
+++ b/backend/server/src/test/java/com/issuetracker/controller/web/WebLabelControllerIntegrationTest.java
@@ -1,0 +1,30 @@
+package com.issuetracker.controller.web;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+
+import static io.restassured.RestAssured.get;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class WebLabelControllerIntegrationTest {
+    @LocalServerPort
+    public int port;
+
+    @BeforeEach
+    void setup() {
+        RestAssured.baseURI = "http://localhost/api/web/labels";
+        RestAssured.port = port;
+    }
+
+    @Test
+    void 라벨을_조회하면_상태코드_200() {
+        get()
+                .then()
+                .assertThat()
+                .log().ifValidationFails()
+                .statusCode(200);
+    }
+}

--- a/backend/server/src/test/java/com/issuetracker/controller/web/WebMilestoneControllerIntegrationTest.java
+++ b/backend/server/src/test/java/com/issuetracker/controller/web/WebMilestoneControllerIntegrationTest.java
@@ -1,0 +1,26 @@
+package com.issuetracker.controller.web;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class WebMilestoneControllerIntegrationTest {
+    @LocalServerPort
+    public int port;
+
+    @BeforeEach
+    void setup() {
+        RestAssured.baseURI = "http://localhost/api/web/milestones";
+        RestAssured.port = port;
+    }
+
+    @Test
+    void 마일스톤_조회할_떄_상태코드_200() {
+        RestAssured.get()
+                .then()
+                .statusCode(200);
+    }
+}


### PR DESCRIPTION
Closes #216

기존 프로젝트의 API 테스트를 작성하려고 하는데, 

작성하면서도 이게 맞나? 라는 생각이 계속 들어서, 개발을 멈추고 엄청 가벼운 단위의 PR 요청 드립니다.

(이슈에 고민의 흔적을 남겨 뒀습니다 ㅋㅋㅋㅋ)

---

### 우선 고민 했던 내용을 말씀드리면

## **1. 어떤 것부터, 뭐부터 테스트를 해야 하는 지였습니다.**

완성된 프로젝트를 테스트하려니 도메인 단위로 (CRUD) 테스트를 끊어야 할 지, 
아니면 조회 테스트, 생성 테스트 와 같이 HTTP 메서드 단위로 테스트를 해야 할 지 였습니다.

-> 이 부분은 예전에 API 개발할 때, 
조회, 생성 각각 구현하는 방식으로 진행하는 게 빠르다는 게 생각이 나서  
같은 맥락??으로 HTTP 메서드 단위로 테스트를 진행했습니다.



## **2. 통합 테스트와 인수 테스트의 의미도 헷갈리기 시작했습니다.**

혹시 제가 이해한 게 맞을까요?

통합 테스트
 - DB - 스프링 컨테이너와 같은 프로젝트와 연결된 환경을 구축한 채로 진행하는 테스트
 - 비즈니스 로직 검증이 주목적

인수 테스트
- 사용자 입장으로, 브라우저 - 서버간 요청이 오고가는 것을 테스트한다.
- 비즈니스 로직을 중요시 하기보다는 `요청 - 응답`의 느낌



## **3. 지금 우선 조회 인수 테스트만 해두었는데, 테스트를 맞게 작성했는지 모르겠습니다.** 

- 제가 생각하기에는 의미 없는 상태 코드 검사만 한 것 같습니다..
- 생성을 못하니 할 수 있는 테스트가 없어서 어떻게 해야 할 지 감이 오지 않네요.